### PR TITLE
Add a basic flatpak manifest

### DIFF
--- a/com.github.alcinnz.odysseus.json
+++ b/com.github.alcinnz.odysseus.json
@@ -1,0 +1,74 @@
+{
+    "app-id" : "com.github.alcinnz.odysseus",
+    "base": "io.elementary.BaseApp",
+    "base-version": "juno",
+    "runtime": "org.gnome.Platform",
+    "sdk": "org.gnome.Sdk",
+    "runtime-version": "3.32",
+    "command" : "com.github.alcinnz.odysseus",
+    "finish-args" : [
+        "--share=ipc",
+        "--share=network",
+        "--socket=x11",
+        "--socket=wayland",
+
+        "--device=dri",
+        "--socket=pulseaudio",
+
+        "--filesystem=xdg-run/dconf",
+        "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf",
+        "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    ],
+    "cleanup" : [
+        "/include",
+        "/lib/pkgconfig",
+        "/share/pkgconfig",
+        "/share/aclocal",
+        "/man",
+        "/share/man",
+        "/share/gtk-doc",
+        "*.la",
+        "*.a",
+        "/lib/girepository-1.0",
+        "/share/dbus-1",
+        "/share/doc",
+        "/share/gir-1.0"
+    ],
+    "modules" : [
+        {
+            "name" : "yaml",
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://github.com/yaml/libyaml.git"
+                }
+            ]
+        },
+        {
+            "name" : "appstream",
+            "buildsystem" : "meson",
+            "config-opts" : [
+                "-Dstemming=false",
+                "-Dvapi=true"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://github.com/ximion/appstream.git"
+                }
+            ]
+        },
+        {
+            "name" : "odysseus",
+            "buildsystem" : "meson",
+            "builddir" : true,
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://github.com/alcinnz/Odysseus.git"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
![Screenshot from 2019-05-28 01-28-52](https://user-images.githubusercontent.com/1510457/58438402-32723d80-80be-11e9-8bc0-0f8190f2d097.png)

Would need further adjustments for Flathub, but here's a very basic one. (also, elementary apps on Flathub ship patches to hardcode elementary theme and icons, like https://github.com/flathub/com.github.cassidyjames.dippi/blob/master/elementary-theme.patch, you may want this too)