### PR TITLE
nix: fix #173

### DIFF
--- a/nix/odysseus.nix
+++ b/nix/odysseus.nix
@@ -40,4 +40,11 @@ stdenv.mkDerivation {
     webkitgtk
   ];
 
+  meta = with stdenv.lib; {
+    description = "A simple and performant yet powerful elementary OS-style window onto the open decentralized web";
+    homepage = "https://odysseus.adrian.geek.nz";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.worldofpeace ];
+  };
 }

--- a/nix/odysseus.nix
+++ b/nix/odysseus.nix
@@ -1,19 +1,43 @@
-{ stdenv
+{ stdenv, substituteAll
 , appstream, cmake, gcr, gettext, glib, granite, gtk3
 , html-xml-utils, json-glib, libgee, libsoup, meson, ninja, pkgconfig, python3
-, sqlite, vala, webkitgtk
+, sqlite, vala, webkitgtk, glib-networking, wrapGAppsHook
 }:
 
 stdenv.mkDerivation {
   name = "odysseus";
-  nativeBuildInputs = [ gettext meson ninja pkgconfig python3 vala ];
-  buildInputs = [ appstream gcr glib granite gtk3 json-glib
-                  libgee libsoup sqlite webkitgtk ];
+
   src = ./..;
 
-  patches = [ ./patches/hxwls-path.patch ];
-  hxwls = "${html-xml-utils}/bin/hxwls";
-  postPatch = ''
-    substituteAllInPlace src/Models/Links.vala
-  '';
+  patches = [
+    (substituteAll {
+      src = ./patches/hxwls-path.patch;
+      hxwls = "${html-xml-utils}/bin/hxwls";
+    })
+  ];
+
+  nativeBuildInputs = [
+    gettext
+    meson
+    ninja
+    pkgconfig
+    python3
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    appstream
+    gcr
+    glib
+    glib-networking
+    granite
+    gtk3
+    json-glib
+    libgee
+    libsoup
+    sqlite
+    webkitgtk
+  ];
+
 }


### PR DESCRIPTION
We need glib-networking's gio module to support TLS/SSL.

Also couldn't help myself fix other things. (listed in the following)
* use `substituteAll` in `patches`
* add `wrapGAppsHook`
  This is needed for all GTK applications.